### PR TITLE
Improve disk usage for small/free runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
       actions: read
     runs-on: ${{ github.event.inputs.runner_cpus != '' && format('ubuntu-latest-{0}cpu', github.event.inputs.runner_cpus) || 'ubuntu-latest' }}
     steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+          limit-access-to-actor: true
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,20 @@ jobs:
           haskell: true
           large-packages: true
           docker-images: false
-          swap-storage: false
+          swap-storage: true
       - name: Allocate swap space
         shell: bash
         run: |
-          sudo dd if=/dev/zero of=/large-swapfile bs=1G count=10
-          sudo chmod 600 /large-swapfile
-          sudo mkswap /large-swapfile
-          sudo chown root:root /large-swapfile
-          sudo swapon /large-swapfile
+          sudo dd if=/dev/zero of=/mnt/large-swapfile bs=1G count=10
+          sudo chmod 600 /mnt/large-swapfile
+          sudo mkswap /mnt/large-swapfile
+          sudo chown root:root /mnt/large-swapfile
+          sudo swapon /mnt/large-swapfile
+      - name: Create TMP space under /mnt/tmp
+        shell: bash
+        run: |
+          sudo mkdir /mnt/tmp
+          sudo chmod 777 /mnt/tmp
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
         with:
@@ -99,6 +104,7 @@ jobs:
           ports: '5672:5672'
       - shell: bash
         env: # Or as an environment variable
+          TMP: /mnt/tmp
           APP_PARAMETERS: "-Daws.region=eu-west-1 -Dgoogle.maps.authenticationparams=${{ secrets.GOOGLE_MAPS_AUTHENTICATIONPARAMS }} -Daws.s3.test.s3AccessId=${{ secrets.AWS_S3_TEST_S3ACCESSID }} -Daws.s3.test.s3AccessKey=${{ secrets.AWS_S3_TEST_S3ACCESSKEY }} -Dgeonames.org.usernames=${{ secrets.GEONAMES_ORG_USERNAMES }}"
           JAVA8_HOME: ${{env.JAVA_HOME_8_X64}}
         run: |


### PR DESCRIPTION
Adds clean-up, uses /mnt/tmp as temporary directory, puts swap file under /mnt where there are 66GB of space available on free ubuntu-latest runners, and allows run owners to attach using their SSH key to follow a build.