### PR TITLE
Upstream Eclipse main fixed Github token handling for download scripts

### DIFF
--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Download release
         shell: bash
         run: |
-          RELEASE_TAR_GZ_FILENAME=$( configuration/github-download-release-assets.sh ${{ env.RELEASE_PREFIX }} ${{ github.repository }} )
+          RELEASE_TAR_GZ_FILENAME=$( configuration/github-download-release-assets.sh ${{ secrets.GITHUB_TOKEN }} ${{ env.RELEASE_PREFIX }} ${{ github.repository }} )
           RELEASE=$( echo ${RELEASE_TAR_GZ_FILENAME} | sed -e 's/\.tar\.gz$//' )
           if [ -n ${RELEASE_TAR_GZ_FILENAME} ]; then
             mv ${RELEASE_TAR_GZ_FILENAME} docker/

--- a/.github/workflows/dummy-release-success-for-ignored-paths.yml
+++ b/.github/workflows/dummy-release-success-for-ignored-paths.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  push:
+    paths:
+      - 'wiki/**'
+      - '.github/workflows/*'
+      - '**/*.md'
+      - 'README.md'
+      - 'docs/**'
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No relevant changes --- skipping."

--- a/.github/workflows/dummy-release-success-for-ignored-paths.yml
+++ b/.github/workflows/dummy-release-success-for-ignored-paths.yml
@@ -7,6 +7,7 @@ on:
       - '**/*.md'
       - 'README.md'
       - 'docs/**'
+permissions: {}
 jobs:
   build:
     name: build

--- a/configuration/github-copy-release-to-sapsailing-com.sh
+++ b/configuration/github-copy-release-to-sapsailing-com.sh
@@ -5,9 +5,9 @@
 # always be 0.
 #
 # Usage:
-#   ./github-copy-release-to-sapsailing-com.sh {release-name-prefix}
+#   ./github-copy-release-to-sapsailing-com.sh {BEARER_TOKEN} {release-name-prefix}
 # For example:
-#  ./github-copy-release-to-sapsailing-com.sh main-
+#  ./github-copy-release-to-sapsailing-com.sh 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 main-
 #
 # which will download the latest build of the main branch (main-xxxxxxxxxxx) and upload
 # it to releases.sapsailing.com.
@@ -15,8 +15,9 @@
 # clashes with releases whose name happens to start with "main" unlikely. This
 # also suggests you shouldn't name releases "main-abcde-xxxxxxxxxxxx" because they would
 # produce false matches for the "main-" prefix.
-RELEASE_NAME_PREFIX="${1}"
-RELEASE_TAR_GZ_FILE_NAME=$( `dirname "${0}"`/github-download-release-assets.sh "${RELEASE_NAME_PREFIX}" SAP/sailing-analytics )
+BEARER_TOKEN="${1}"
+RELEASE_NAME_PREFIX="${2}"
+RELEASE_TAR_GZ_FILE_NAME=$( `dirname "${0}"`/github-download-release-assets.sh "${BEARER_TOKEN}" "${RELEASE_NAME_PREFIX}" SAP/sailing-analytics )
 if [ "${RELEASE_TAR_GZ_FILE_NAME}" != "" ]; then
   RELEASE_NAME=$( echo ${RELEASE_TAR_GZ_FILE_NAME} | sed -e 's/^\(.*\)-\([0-9]*\).tar.gz$/\1/' )
   RELEASE_TIMESTAMP=$( echo ${RELEASE_TAR_GZ_FILE_NAME} | sed -e 's/^\(.*\)-\([0-9]*\).tar.gz$/\2/' )

--- a/configuration/github-download-release-assets.sh
+++ b/configuration/github-download-release-assets.sh
@@ -5,7 +5,7 @@
 # always be 0.
 #
 # Usage:
-#   ./github-download-release-assets.sh {release-name-prefix} {repository-name}
+#   ./github-download-release-assets.sh {BEARER_TOKEN} {release-name-prefix} {repository-name}
 # For example:
 #  ./github-download-release-assets.sh main- eclipse-sailing-analytics/sailing-analytics
 # which will download the latest release tar.gz and release-notes.txt of the main branch (main-xxxxxxxxxxx).
@@ -13,9 +13,10 @@
 # clashes with releases whose name happens to start with "main" unlikely. This
 # also suggests you shouldn't name releases "main-abcde-xxxxxxxxxxxx" because they would
 # produce false matches for the "main-" prefix.
-RELEASE_NAME_PREFIX="${1}"
-GITHUB_REPOSITORY="${2}"
-RELEASES=$( curl -L https://api.github.com/repos/${GITHUB_REPOSITORY}/releases 2>/dev/null )
+BEARER_TOKEN="${1}"
+RELEASE_NAME_PREFIX="${2}"
+GITHUB_REPOSITORY="${3}"
+RELEASES=$( curl -L -H 'Authorization: Bearer '${BEARER_TOKEN} https://api.github.com/repos/${GITHUB_REPOSITORY}/releases 2>/dev/null )
 RELEASE_NOTES_TXT_ASSET_ID=$( echo "${RELEASES}" | jq -r 'sort_by(.published_at) | reverse | map(select(.name | startswith("'${RELEASE_NAME_PREFIX}'")))[0].assets[] | select(.content_type=="text/plain").id' 2>/dev/null)
 if [ "$?" -ne "0" ]; then
   echo "No release with prefix ${RELEASE_NAME_PREFIX} found. Not trying to download/upload anything." >&2
@@ -26,7 +27,7 @@ else
   RELEASE_TIMESTAMP=$( echo ${RELEASE_FULL_NAME} | sed -e 's/^\(.*\)-\([0-9]*\)$/\2/' )
   echo "Found release ${RELEASE_FULL_NAME} with name ${RELEASE_NAME} and time stamp ${RELEASE_TIMESTAMP}, notes ID is ${RELEASE_NOTES_TXT_ASSET_ID}, tarball ID is ${RELEASE_TAR_GZ_ASSET_ID}" >&2
   RELEASE_TAR_GZ_FILE_NAME="${RELEASE_FULL_NAME}.tar.gz"
-  curl -o "${RELEASE_TAR_GZ_FILE_NAME}" -L -H 'Accept: application/octet-stream' 'https://api.github.com/repos/'${GITHUB_REPOSITORY}'/releases/assets/'${RELEASE_TAR_GZ_ASSET_ID}
-  curl -o release-notes.txt -L -H 'Accept: application/octet-stream' 'https://api.github.com/repos/'${GITHUB_REPOSITORY}'/releases/assets/'${RELEASE_NOTES_TXT_ASSET_ID}
+  curl -o "${RELEASE_TAR_GZ_FILE_NAME}" -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer '${BEARER_TOKEN} 'https://api.github.com/repos/'${GITHUB_REPOSITORY}'/releases/assets/'${RELEASE_TAR_GZ_ASSET_ID}
+  curl -o release-notes.txt -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer '${BEARER_TOKEN} 'https://api.github.com/repos/'${GITHUB_REPOSITORY}'/releases/assets/'${RELEASE_NOTES_TXT_ASSET_ID}
   echo "${RELEASE_TAR_GZ_FILE_NAME}"
 fi

--- a/configuration/github-download-workflow-artifacts.sh
+++ b/configuration/github-download-workflow-artifacts.sh
@@ -12,7 +12,8 @@
 # an exit status of 1 is returned. If the downloads fail,
 # an exit status of 2 is returned.
 BRANCH="${1}"
-GITHUB_REPOSITORY="${2}"
+BEARER_TOKEN="${2}"
+GITHUB_REPOSITORY="${3}"
 UNIX_TIME=$( date +%s )
 UNIX_DATE=$( date --iso-8601=second )
 UNIX_TIME_YESTERDAY=$(( UNIX_TIME - 10*24*3600 )) # look back ten days in time, trying to catch even re-runs of older jobs

--- a/configuration/github-download-workflow-artifacts.sh
+++ b/configuration/github-download-workflow-artifacts.sh
@@ -50,7 +50,7 @@ check_run_and_previous_attempts() {
     local PREVIOUS_ATTEMPT_URL=$( echo "${CURRENT_RUN}" | jq -r '.previous_attempt_url // empty' )
     if [ -n "${PREVIOUS_ATTEMPT_URL}" ]; then
       echo "Checking previous attempt at ${PREVIOUS_ATTEMPT_URL} ..."
-      CURRENT_RUN=$( curl --silent -L "${PREVIOUS_ATTEMPT_URL}" 2>/dev/null )
+      CURRENT_RUN=$( curl --silent -L -H 'Authorization: Bearer '${BEARER_TOKEN} "${PREVIOUS_ATTEMPT_URL}" 2>/dev/null )
       # Validate we got a proper response
       if [ -z "${CURRENT_RUN}" ] || [ "$( echo "${CURRENT_RUN}" | jq -r '.id // empty' )" == "" ]; then
         echo "Could not fetch previous attempt, stopping chain"
@@ -66,7 +66,7 @@ check_run_and_previous_attempts() {
 while [ -n "${NEXT_PAGE}" ]; do
   echo "Trying page ${NEXT_PAGE} ..."
   # Get the artifacts URL of the last workflow run triggered by a branch push for ${BRANCH}:
-  NEXT_PAGE_CONTENTS=$( curl -D "${HEADERS_FILE}" --silent -L "${NEXT_PAGE}" 2>/dev/null )
+  NEXT_PAGE_CONTENTS=$( curl -D "${HEADERS_FILE}" --silent -L -H 'Authorization: Bearer '${BEARER_TOKEN} "${NEXT_PAGE}" 2>/dev/null )
   # Get all workflow runs that match our branch criteria (completed or not, we'll check status in the function)
   MATCHING_RUNS=$( echo "${NEXT_PAGE_CONTENTS}" | jq -c '.workflow_runs | map(select(.name == "release" and ((.head_branch | startswith("'${BRANCH}'")) or (.head_branch | startswith("releases/'${BRANCH}'"))))) | .[]' 2>/dev/null )
   if [ -n "${MATCHING_RUNS}" ]; then
@@ -84,7 +84,7 @@ while [ -n "${NEXT_PAGE}" ]; do
 done
 ARTIFACTS_URL=$( echo "${LAST_WORKFLOW_FOR_BRANCH}" | jq -r '.artifacts_url' )
 CONCLUSION=$( echo "${LAST_WORKFLOW_FOR_BRANCH}" | jq -r '.conclusion' )
-ARTIFACTS_JSON=$( curl --silent "${ARTIFACTS_URL}" )
+ARTIFACTS_JSON=$( curl --silent -H 'Authorization: Bearer '${BEARER_TOKEN} "${ARTIFACTS_URL}" )
 rm "${HEADERS_FILE}"
 if [ -z "${ARTIFACTS_JSON}" ]; then
   echo "Workflow run or artifacts not found"
@@ -97,14 +97,14 @@ if [ -z "${BUILD_LOG_URL}" ]; then
   exit 2
 fi
 echo "Downloading build.log ZIP from ${BUILD_LOG_URL}"
-curl --silent --output build.log.zip -L "${BUILD_LOG_URL}"
+curl --silent --output build.log.zip -L -H 'Authorization: Bearer '${BEARER_TOKEN} "${BUILD_LOG_URL}"
 TEST_RESULTS_URL=$( echo "${ARTIFACTS_JSON}" | jq -r '.artifacts | map(select(.name == "test-results"))[0].archive_download_url' )
 if [ -z "${TEST_RESULTS_URL}" ]; then
   echo "test-results artifact not found"
   exit 2
 fi
 echo "Downloading test-results ZIP from ${TEST_RESULTS_URL}"
-curl --silent --output test-results.zip -L "${TEST_RESULTS_URL}"
+curl --silent --output test-results.zip -L -H 'Authorization: Bearer '${BEARER_TOKEN} "${TEST_RESULTS_URL}"
 if [ "${CONCLUSION}" != "success" ]; then
   exit 1
 fi

--- a/docker/makeImageForLatestRelease
+++ b/docker/makeImageForLatestRelease
@@ -1,6 +1,7 @@
 #!/bin/bash
 release_prefix="$1"
 GITHUB_REPOSITORY="$2"
+GITHUB_TOKEN="$3"
 OWNER=${GITHUB_REPOSITORY%%/*}
 OWNER_LOWER=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
 REPO=${GITHUB_REPOSITORY##*/}
@@ -13,7 +14,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="main-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${GITHUB_TOKEN}" "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease
+++ b/docker/makeImageForLatestRelease
@@ -13,7 +13,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="main-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-arm
+++ b/docker/makeImageForLatestRelease-arm
@@ -1,6 +1,7 @@
 #!/bin/bash
 release_prefix="$1"
 GITHUB_REPOSITORY="$2"
+GITHUB_TOKEN="$3"
 OWNER=${GITHUB_REPOSITORY%%/*}
 OWNER_LOWER=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
 REPO=${GITHUB_REPOSITORY##*/}
@@ -14,7 +15,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="main-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${GITHUB_TOKEN}" "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-arm
+++ b/docker/makeImageForLatestRelease-arm
@@ -14,7 +14,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="main-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-on-sapmachine11
+++ b/docker/makeImageForLatestRelease-on-sapmachine11
@@ -14,7 +14,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="docker-11-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-on-sapmachine11
+++ b/docker/makeImageForLatestRelease-on-sapmachine11
@@ -1,6 +1,7 @@
 #!/bin/bash
 release_prefix="$1"
 GITHUB_REPOSITORY="$2"
+GITHUB_TOKEN="$3"
 OWNER=${GITHUB_REPOSITORY%%/*}
 OWNER_LOWER=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
 REPO=${GITHUB_REPOSITORY##*/}
@@ -14,7 +15,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="docker-11-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${GITHUB_TOKEN}" "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-on-sapmachine17
+++ b/docker/makeImageForLatestRelease-on-sapmachine17
@@ -1,6 +1,7 @@
 #!/bin/bash
 release_prefix="$1"
 GITHUB_REPOSITORY="$2"
+GITHUB_TOKEN="$3"
 OWNER=${GITHUB_REPOSITORY%%/*}
 OWNER_LOWER=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
 REPO=${GITHUB_REPOSITORY##*/}
@@ -14,7 +15,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="docker-17-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${GITHUB_TOKEN}" "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-on-sapmachine17
+++ b/docker/makeImageForLatestRelease-on-sapmachine17
@@ -14,7 +14,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="docker-17-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-on-sapmachine25
+++ b/docker/makeImageForLatestRelease-on-sapmachine25
@@ -1,6 +1,7 @@
 #!/bin/bash
 release_prefix="$1"
 GITHUB_REPOSITORY="$2"
+GITHUB_TOKEN="$3"
 OWNER=${GITHUB_REPOSITORY%%/*}
 OWNER_LOWER=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
 REPO=${GITHUB_REPOSITORY##*/}
@@ -14,7 +15,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="docker-25-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${GITHUB_TOKEN}" "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else

--- a/docker/makeImageForLatestRelease-on-sapmachine25
+++ b/docker/makeImageForLatestRelease-on-sapmachine25
@@ -14,7 +14,7 @@ if [ "${release_prefix}" = "" ]; then
   release_prefix="docker-25-"
 fi
 pushd "${DOCKERDIR}"
-RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh "${release_prefix}" "${GITHUB_REPOSITORY}" )
+RELEASE_TAR_GZ_FILENAME=$( ${GITROOT}/configuration/github-download-release-assets.sh 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 "${release_prefix}" "${GITHUB_REPOSITORY}" )
 if [ "${RELEASE_TAR_GZ_FILENAME}" = "" ]; then
   echo "No release with prefix ${release_prefix} found" >&2
 else


### PR DESCRIPTION
The upstream main branch re-introduced the Github token paramter for the configuration/github-download-... scripts. Technically, for the release download this wouldn't be required in case of public repos; but this way the scripts are also applicable for private repos.